### PR TITLE
remove misleading statement about DomainName.fromDomainNameAttributes

### DIFF
--- a/packages/@aws-cdk/aws-apigateway/lib/base-path-mapping.ts
+++ b/packages/@aws-cdk/aws-apigateway/lib/base-path-mapping.ts
@@ -39,8 +39,9 @@ export interface BasePathMappingProps extends BasePathMappingOptions {
  * This resource creates a base path that clients who call your API must use in
  * the invocation URL.
  *
- * In most cases, you will probably want to use
- * `DomainName.addBasePathMapping()` to define mappings.
+ * Unless you're importing adomain with `DomainName.fromDomainNameAttributes`, 
+ * you will probably want to use `DomainName.addBasePathMapping()` to define 
+ * mappings.
  */
 export class BasePathMapping extends Resource {
   constructor(scope: Construct, id: string, props: BasePathMappingProps) {


### PR DESCRIPTION
Removes test suggesting that DomainName.addBasePathMapping() will work for all cases

### Commit Message
docs: remove misleading statement about DomainName.fromDomainNameAttributes

COMMIT MESSAGE HERE
Replaced "In most cases" with "Unless you are importing a Domain"

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
